### PR TITLE
replaced table.pack with {...}

### DIFF
--- a/lua/faust-nvim/compiler.lua
+++ b/lua/faust-nvim/compiler.lua
@@ -36,7 +36,8 @@ function M.get_faust2_names()
 end
 
 function M.load_command(...)
-	local args = table.pack(...)
+    local args = {...}
+
 	local command = args[1]
 
 	-- Remove command from argument list


### PR DESCRIPTION
The table methods are not available in lua 5.1, which is the supported version in nvim. Replacing `table.pack(...)` with `{...}` solves this issue.